### PR TITLE
Add main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ng-pattern-restrict",
   "version": "0.2.1",
+  "main": "src/ng-pattern-restrict.min.js",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
`Cannot find module 'ng-pattern-restrict'`

Browserify throws this error when it tries to require the module.
